### PR TITLE
Add REMIND input data

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '10268910'
+ValidationKey: '10288620'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrland: MadRaT land data package'
-version: 0.52.1
+version: 0.52.2
 date-released: '2023-12-19'
 abstract: The package provides land related data via the madrat framework.
 authors:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mrland
 Title: MadRaT land data package
-Version: 0.52.1
+Version: 0.52.2
 Date: 2023-12-19
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),

--- a/R/readREMIND.R
+++ b/R/readREMIND.R
@@ -17,9 +17,9 @@ readREMIND <- function(subtype) {
 
   .readAndRename <- function(fileList, pattern, replacement) {
     x <- NULL
-    for(f in file_list) {
+    for (f in fileList) {
       # select REMIND only since newer coupled REMIND reportings also contain MAgPIE
-      x <- mbind(x, read.report(f, as.list = FALSE)[,,"REMIND"])
+      x <- mbind(x, read.report(f, as.list = FALSE)[, , "REMIND"])
     }
     # remove model and variable name
     x <- collapseNames(x)
@@ -29,65 +29,65 @@ readREMIND <- function(subtype) {
   }
 
   # Please refer to the 2019-R2M41/readme.txt for the source of the data
-  file_list <- c("2019-R2M41/REMIND_generic_r8473-trunk-C_Budg600-rem-5.mif",
-                 "2019-R2M41/REMIND_generic_r8473-trunk-C_Budg950-rem-5.mif",
-                 "2019-R2M41/REMIND_generic_r8473-trunk-C_Budg1300-rem-5.mif",
-                 "2019-R2M41/REMIND_generic_r8473-trunk-C_NDC-rem-5.mif",
-                 "2019-R2M41/REMIND_generic_r8473-trunk-C_NPi-rem-5.mif")
+  fileList <- c("2019-R2M41/REMIND_generic_r8473-trunk-C_Budg600-rem-5.mif",
+                "2019-R2M41/REMIND_generic_r8473-trunk-C_Budg950-rem-5.mif",
+                "2019-R2M41/REMIND_generic_r8473-trunk-C_Budg1300-rem-5.mif",
+                "2019-R2M41/REMIND_generic_r8473-trunk-C_NDC-rem-5.mif",
+                "2019-R2M41/REMIND_generic_r8473-trunk-C_NPi-rem-5.mif")
 
-  out <- .readAndRename(fileList = file_list, pattern = "r8473-trunk-C_", replacement = "R2M41-SSP2-")
+  out <- .readAndRename(fileList = fileList, pattern = "r8473-trunk-C_", replacement = "R2M41-SSP2-")
 
-  if(grepl("_",subtype)){
+  if (grepl("_", subtype)) {
 
-    subtype     <- strsplit(subtype, split="_")
-    revision    <- as.numeric(unlist(subtype)[2])
+    subtype  <- strsplit(subtype, split = "_")
+    revision <- as.numeric(unlist(subtype)[2])
 
     if (revision > 4.58) {
       # Please refer to the 2021-R21M42/readme.txt for the source of the data
-      file_list <- c("2021-R21M42/REMIND_generic_C_SDP-NPi-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SDP-PkBudg900-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SDP-PkBudg1000-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SDP-PkBudg1100-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP1-NPi-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP1-PkBudg900-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP1-PkBudg1100-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP1-PkBudg1300-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP2-NPi-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP2-PkBudg900-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP2-PkBudg1100-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP2-PkBudg1300-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP5-NPi-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP5-PkBudg900-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP5-PkBudg1100-rem-5.mif",
-                     "2021-R21M42/REMIND_generic_C_SSP5-PkBudg1300-rem-5.mif")
+      fileList <- c("2021-R21M42/REMIND_generic_C_SDP-NPi-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SDP-PkBudg900-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SDP-PkBudg1000-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SDP-PkBudg1100-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP1-NPi-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP1-PkBudg900-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP1-PkBudg1100-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP1-PkBudg1300-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP2-NPi-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP2-PkBudg900-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP2-PkBudg1100-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP2-PkBudg1300-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP5-NPi-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP5-PkBudg900-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP5-PkBudg1100-rem-5.mif",
+                    "2021-R21M42/REMIND_generic_C_SSP5-PkBudg1300-rem-5.mif")
 
-      out <- mbind(out, .readAndRename(fileList = file_list, pattern = "C_(SDP|SSP)", replacement = "R21M42-\\1"))
+      out <- mbind(out, .readAndRename(fileList = fileList, pattern = "C_(SDP|SSP)", replacement = "R21M42-\\1"))
     }
 
     if (revision >= 4.96) {
       # Please refer to the 2023-R32M46/readme.txt for the source of the data
-      file_list <- c("2023-R32M46/REMIND_generic_C_SDP_MC-NDC-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SDP_MC-NPi-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SDP_MC-PkBudg650-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP1-NDC-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP1-NPi-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP1-PkBudg1050-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP1-PkBudg650-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP2EU-NDC-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP2EU-NPi-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP2EU-PkBudg1050-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP2EU-PkBudg650-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP5-NDC-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP5-NPi-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP5-PkBudg1050-rem-5.mif",
-                     "2023-R32M46/REMIND_generic_C_SSP5-PkBudg650-rem-5.mif")
+      fileList <- c("2023-R32M46/REMIND_generic_C_SDP_MC-NDC-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SDP_MC-NPi-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SDP_MC-PkBudg650-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP1-NDC-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP1-NPi-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP1-PkBudg1050-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP1-PkBudg650-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP2EU-NDC-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP2EU-NPi-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP2EU-PkBudg1050-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP2EU-PkBudg650-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP5-NDC-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP5-NPi-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP5-PkBudg1050-rem-5.mif",
+                    "2023-R32M46/REMIND_generic_C_SSP5-PkBudg650-rem-5.mif")
 
-      out <- mbind(out, .readAndRename(fileList = file_list, pattern = "C_(SDP_MC|SSP)", replacement = "R32M46-\\1"))
+      out <- mbind(out, .readAndRename(fileList = fileList, pattern = "C_(SDP_MC|SSP)", replacement = "R32M46-\\1"))
     }
   }
 
   # shorten names of the REMIND scenarios
-  getNames(out) <- gsub("-rem-5","",getNames(out))
+  getNames(out) <- gsub("-rem-5", "", getNames(out))
 
   return(out)
 

--- a/R/readREMIND.R
+++ b/R/readREMIND.R
@@ -1,67 +1,94 @@
 #' @title readREMIND
 #' @description Reads in a reporting mif file from REMIND
-#' 
+#'
 #' @param subtype Either "intensive" or "extensive"
 #' @return MAgPIE object with regional aggregation of REMIND H12
 #' @author David Klein
 #' @seealso
 #' \code{\link{readSource}}
 #' @examples
-#' 
-#' \dontrun{ 
+#'
+#' \dontrun{
 #' readSource("REMIND",aggregate=FALSE)
 #' }
 #' @importFrom magclass read.report
 
 readREMIND <- function(subtype) {
-  
-  # /p/projects/remind/runs/r8473-trunk-C/output/r8473-trunk-C_*/report.mif
-  
-  file_list <- c("REMIND_generic_r8473-trunk-C_Budg600-rem-5.mif",
-                 "REMIND_generic_r8473-trunk-C_Budg950-rem-5.mif",
-                 "REMIND_generic_r8473-trunk-C_Budg1300-rem-5.mif",
-                 "REMIND_generic_r8473-trunk-C_NDC-rem-5.mif",
-                 "REMIND_generic_r8473-trunk-C_NPi-rem-5.mif")
-  
+
+  .readAndRename <- function(fileList, pattern, replacement) {
+    x <- NULL
+    for(f in file_list) {
+      # select REMIND only since newer coupled REMIND reportings also contain MAgPIE
+      x <- mbind(x, read.report(f, as.list = FALSE)[,,"REMIND"])
+    }
+    # remove model and variable name
+    x <- collapseNames(x)
+    # shorten names of the REMIND scenarios
+    getNames(x) <- gsub(pattern, replacement, getNames(x))
+    return(x)
+  }
+
+  # Please refer to the 2019-R2M41/readme.txt for the source of the data
+  file_list <- c("2019-R2M41/REMIND_generic_r8473-trunk-C_Budg600-rem-5.mif",
+                 "2019-R2M41/REMIND_generic_r8473-trunk-C_Budg950-rem-5.mif",
+                 "2019-R2M41/REMIND_generic_r8473-trunk-C_Budg1300-rem-5.mif",
+                 "2019-R2M41/REMIND_generic_r8473-trunk-C_NDC-rem-5.mif",
+                 "2019-R2M41/REMIND_generic_r8473-trunk-C_NPi-rem-5.mif")
+
+  out <- .readAndRename(fileList = file_list, pattern = "r8473-trunk-C_", replacement = "R2M41-SSP2-")
+
   if(grepl("_",subtype)){
-    
+
     subtype     <- strsplit(subtype, split="_")
     revision    <- as.numeric(unlist(subtype)[2])
 
     if (revision > 4.58) {
-      file_list <- c(file_list,
-                     "REMIND_generic_C_SDP-NPi-rem-5.mif",
-                     "REMIND_generic_C_SDP-PkBudg900-rem-5.mif",
-                     "REMIND_generic_C_SDP-PkBudg1000-rem-5.mif",
-                     "REMIND_generic_C_SDP-PkBudg1100-rem-5.mif",
-                     "REMIND_generic_C_SSP1-NPi-rem-5.mif",     
-                     "REMIND_generic_C_SSP1-PkBudg900-rem-5.mif",
-                     "REMIND_generic_C_SSP1-PkBudg1100-rem-5.mif",
-                     "REMIND_generic_C_SSP1-PkBudg1300-rem-5.mif",
-                     "REMIND_generic_C_SSP2-NPi-rem-5.mif",
-                     "REMIND_generic_C_SSP2-PkBudg900-rem-5.mif",
-                     "REMIND_generic_C_SSP2-PkBudg1100-rem-5.mif",
-                     "REMIND_generic_C_SSP2-PkBudg1300-rem-5.mif",
-                     "REMIND_generic_C_SSP5-NPi-rem-5.mif",
-                     "REMIND_generic_C_SSP5-PkBudg900-rem-5.mif",
-                     "REMIND_generic_C_SSP5-PkBudg1100-rem-5.mif",
-                     "REMIND_generic_C_SSP5-PkBudg1300-rem-5.mif")
+      # Please refer to the 2021-R21M42/readme.txt for the source of the data
+      file_list <- c("2021-R21M42/REMIND_generic_C_SDP-NPi-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SDP-PkBudg900-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SDP-PkBudg1000-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SDP-PkBudg1100-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP1-NPi-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP1-PkBudg900-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP1-PkBudg1100-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP1-PkBudg1300-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP2-NPi-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP2-PkBudg900-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP2-PkBudg1100-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP2-PkBudg1300-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP5-NPi-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP5-PkBudg900-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP5-PkBudg1100-rem-5.mif",
+                     "2021-R21M42/REMIND_generic_C_SSP5-PkBudg1300-rem-5.mif")
+
+      out <- mbind(out, .readAndRename(fileList = file_list, pattern = "C_(SDP|SSP)", replacement = "R21M42-\\1"))
+    }
+
+    if (revision >= 4.96) {
+      # Please refer to the 2023-R32M46/readme.txt for the source of the data
+      file_list <- c("2023-R32M46/REMIND_generic_C_SDP_MC-NDC-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SDP_MC-NPi-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SDP_MC-PkBudg650-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP1-NDC-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP1-NPi-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP1-PkBudg1050-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP1-PkBudg650-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP2EU-NDC-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP2EU-NPi-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP2EU-PkBudg1050-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP2EU-PkBudg650-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP5-NDC-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP5-NPi-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP5-PkBudg1050-rem-5.mif",
+                     "2023-R32M46/REMIND_generic_C_SSP5-PkBudg650-rem-5.mif")
+
+      out <- mbind(out, .readAndRename(fileList = file_list, pattern = "C_(SDP_MC|SSP)", replacement = "R32M46-\\1"))
     }
   }
-  
-  x <- NULL
-  for(f in file_list) {
-    x <- mbind(x,read.report(f,as.list = FALSE))
-  }
-  
-  # remove model and variable name
-  x <- collapseNames(x)
-  
-  # shorten names of the REMIND scenarios
-  getNames(x) <- gsub("r8473-trunk-C_", "R2M41-SSP2-",getNames(x))
-  getNames(x) <- gsub("C_(SDP|SSP)", "R21M42-\\1",getNames(x))
-  getNames(x) <- gsub("-rem-5","",getNames(x))
 
-  return(x)
+  # shorten names of the REMIND scenarios
+  getNames(out) <- gsub("-rem-5","",getNames(out))
+
+  return(out)
 
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRaT land data package
 
-R package **mrland**, version **0.52.1**
+R package **mrland**, version **0.52.2**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrland)](https://cran.r-project.org/package=mrland) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822083.svg)](https://doi.org/10.5281/zenodo.3822083) [![R build status](https://github.com/pik-piam/mrland/workflows/check/badge.svg)](https://github.com/pik-piam/mrland/actions) [![codecov](https://codecov.io/gh/pik-piam/mrland/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrland) [![r-universe](https://pik-piam.r-universe.dev/badges/mrland)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrland** in publications use:
 
-Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D (2023). _mrland: MadRaT land data package_. doi:10.5281/zenodo.3822083 <https://doi.org/10.5281/zenodo.3822083>, R package version 0.52.1, <https://github.com/pik-piam/mrland>.
+Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D (2023). _mrland: MadRaT land data package_. doi: 10.5281/zenodo.3822083 (URL: https://doi.org/10.5281/zenodo.3822083), R package version 0.52.2, <URL: https://github.com/pik-piam/mrland>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,7 +48,7 @@ A BibTeX entry for LaTeX users is
   title = {mrland: MadRaT land data package},
   author = {Jan Philipp Dietrich and Abhijeet Mishra and Isabelle Weindl and Benjamin Leon Bodirsky and Xiaoxi Wang and Lavinia Baumstark and Ulrich Kreidenweis and David Klein and Nele Steinmetz and David Chen and Florian Humpenoeder and Patrick {von Jeetze} and Stephen Wirth and Felicitas Beier and David Hoetten},
   year = {2023},
-  note = {R package version 0.52.1},
+  note = {R package version 0.52.2},
   doi = {10.5281/zenodo.3822083},
   url = {https://github.com/pik-piam/mrland},
 }

--- a/man/readREMIND.Rd
+++ b/man/readREMIND.Rd
@@ -17,7 +17,7 @@ Reads in a reporting mif file from REMIND
 }
 \examples{
 
-\dontrun{ 
+\dontrun{
 readSource("REMIND",aggregate=FALSE)
 }
 }


### PR DESCRIPTION
Reorganize the way the REMIND data is read:
1. put REMIND reportings into different sub-folders in the REMIND source folder, depending on their production date and model versions
2. read from these sub-folders separatley and mbind afterwards (needed for proper renaming of scenarios)