### PR TITLE
Add new REMIND data (for GHGPrices and 2ndBioDem) from coupled runs

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '131287170'
+ValidationKey: '131385469'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,15 +35,6 @@ jobs:
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install python dependencies if applicable
-        run: |
-          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
-          [ -f requirements.txt ] && pip install -r requirements.txt || true
-
       - name: Run pre-commit checks
         shell: bash
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrland: MadRaT land data package'
-version: 0.65.10
-date-released: '2025-03-20'
+version: 0.65.11
+date-released: '2025-04-01'
 abstract: The package provides land related data via the madrat framework.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrland
 Title: MadRaT land data package
-Version: 0.65.10
-Date: 2025-03-20
+Version: 0.65.11
+Date: 2025-04-01
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Abhijeet", "Mishra", role = "aut"),

--- a/R/calc2ndBioDem.R
+++ b/R/calc2ndBioDem.R
@@ -110,8 +110,14 @@ calc2ndBioDem <- function(datasource, rev = numeric_version("0.1")) {
     yrFut <- years[years >= 2020]
 
     # apply lowpass filter (not applied on 1st time step, applied separately on historic and future period)
+    # only on sceanrios that were existing before revision 4.188
     iter <- 3
-    x <- mbind(x[, 1995, ], lowpass(x[, yrHist, ], i = iter), lowpass(x[, yrFut, ], i = iter)[, -1, ])
+    modelsBeforeRev4188 <- "SSPDB|R2M41|R21M42|R32M46|PIK_NPI|PIK_HOS|PIK_HBL|PIK_OPT|PIK_H2C|PIK_GDP|PIK_LIN"
+    scenariosBeforeRev4188 <- grep(modelsBeforeRev4188, getItems(x, dim = 3), value = TRUE)
+
+    x[,,scenariosBeforeRev4188] <- mbind(x[, 1995, scenariosBeforeRev4188],
+                                         lowpass(x[, yrHist, scenariosBeforeRev4188], i = iter),
+                                         lowpass(x[, yrFut, scenariosBeforeRev4188], i = iter)[, -1, scenariosBeforeRev4188])
 
     # sort scenarios alphabetically
     x <- x[, , sort(getNames(x))]

--- a/R/calc2ndBioDem.R
+++ b/R/calc2ndBioDem.R
@@ -11,7 +11,7 @@
 #' }
 #' @import magclass
 #' @importFrom madrat readSource calcOutput
-#' @importFrom magclass collapseNames time_interpolate mbind
+#' @importFrom magclass collapseNames time_interpolate mbind lowpass
 
 calc2ndBioDem <- function(datasource, rev = numeric_version("0.1")) {
 
@@ -103,6 +103,15 @@ calc2ndBioDem <- function(datasource, rev = numeric_version("0.1")) {
 
     ssp <- time_interpolate(ssp, getYears(rem), extrapolation_type = "constant")
     x <- mbind(ssp, rem, strefler)
+
+    # years
+    years <- getYears(x, as.integer = TRUE)
+    yrHist <- years[years > 1995 & years <= 2020]
+    yrFut <- years[years >= 2020]
+
+    # apply lowpass filter (not applied on 1st time step, applied separately on historic and future period)
+    iter <- 3
+    x <- mbind(x[, 1995, ], lowpass(x[, yrHist, ], i = iter), lowpass(x[, yrFut, ], i = iter)[, -1, ])
 
     # sort scenarios alphabetically
     x <- x[, , sort(getNames(x))]

--- a/R/calc2ndBioDem.R
+++ b/R/calc2ndBioDem.R
@@ -11,7 +11,7 @@
 #' }
 #' @import magclass
 #' @importFrom madrat readSource calcOutput
-#' @importFrom magclass collapseNames time_interpolate mbind lowpass
+#' @importFrom magclass collapseNames time_interpolate mbind
 
 calc2ndBioDem <- function(datasource, rev = numeric_version("0.1")) {
 
@@ -103,15 +103,6 @@ calc2ndBioDem <- function(datasource, rev = numeric_version("0.1")) {
 
     ssp <- time_interpolate(ssp, getYears(rem), extrapolation_type = "constant")
     x <- mbind(ssp, rem, strefler)
-
-    # years
-    years <- getYears(x, as.integer = TRUE)
-    yrHist <- years[years > 1995 & years <= 2020]
-    yrFut <- years[years >= 2020]
-
-    # apply lowpass filter (not applied on 1st time step, applied separately on historic and future period)
-    iter <- 3
-    x <- mbind(x[, 1995, ], lowpass(x[, yrHist, ], i = iter), lowpass(x[, yrFut, ], i = iter)[, -1, ])
 
     # sort scenarios alphabetically
     x <- x[, , sort(getNames(x))]

--- a/R/calcGHGPrices.R
+++ b/R/calcGHGPrices.R
@@ -27,31 +27,31 @@ calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev =
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|Carbon (US$2005/t CO2)"))
-    outC <- x * 44 / 12 # US$2005/tCO2 -> US$2005/tC
+                                     "Price|Carbon (US$2017/t CO2)"))
+    outC <- x * 44 / 12 # US$2017/tCO2 -> US$2017/tC
     outC <- add_dimension(outC, dim = 3.1, nm = "co2_c")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|N2O (US$2005/t N2O)"))
-    outN2oDirect <- x * 44 / 28 # US$2005/tN2O -> US$2005/tN
+                                     "Price|N2O (US$2017/t N2O)"))
+    outN2oDirect <- x * 44 / 28 # US$2017/tN2O -> US$2017/tN
     outN2oDirect <- add_dimension(outN2oDirect, dim = 3.1, nm = "n2o_n_direct")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|N2O (US$2005/t N2O)"))
-    outN2oIndirect <- x[, , ] * 44 / 28 # US$2005/tN2O -> US$2005/tN
+                                     "Price|N2O (US$2017/t N2O)"))
+    outN2oIndirect <- x[, , ] * 44 / 28 # US$2017/tN2O -> US$2017/tN
     outN2oIndirect <- add_dimension(outN2oIndirect, dim = 3.1, nm = "n2o_n_indirect")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|CH4 (US$2005/t CH4)"))
+                                     "Price|CH4 (US$2017/t CH4)"))
     outCh4 <- x[, , ]
     outCh4 <- add_dimension(outCh4, dim = 3.1, nm = "ch4")
 
@@ -68,10 +68,6 @@ calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev =
     x[, , setToZero] <- 0
 
     description <- "GHG certificate prices for different scenarios based on data from REMIND-MAgPIE coupling"
-
-    #convert from USD05MER to USD17MER based on USA values for all countries as the CO2 price is global.
-    x <- x * round(GDPuc::toolConvertSingle(1, "USA", unit_in = "constant 2005 US$MER",
-                                            unit_out = "constant 2017 US$MER"), 2)
 
   } else if (datasource == "Strefler2021") {
     x <- readSource("Strefler2021", subtype = paste0("intensive_", rev))

--- a/R/calcGHGPrices.R
+++ b/R/calcGHGPrices.R
@@ -23,43 +23,35 @@
 calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev = numeric_version("0.1")) {
 
   if (datasource == "REMIND") {
-    
-    # use US$2005 for revisions before 4.118
-    if (rev < 4.118) {
-      dollar <- "US$2005"
-    } else {
-      dollar <- "US$2017"
-    }
-  
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     paste0("Price|Carbon (", dollar, "/t CO2)"))
-    outC <- x * 44 / 12 # US$/tCO2 -> US$/tC
+                                     "Price|Carbon (US$2017/t CO2)"))
+    outC <- x * 44 / 12 # US$2017/tCO2 -> US$2017/tC
     outC <- add_dimension(outC, dim = 3.1, nm = "co2_c")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|N2O (", dollar, "/t N2O)"))
-    outN2oDirect <- x * 44 / 28 # US$/tN2O -> US$/tN
+                                     "Price|N2O (US$2017/t N2O)"))
+    outN2oDirect <- x * 44 / 28 # US$2017/tN2O -> US$2017/tN
     outN2oDirect <- add_dimension(outN2oDirect, dim = 3.1, nm = "n2o_n_direct")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|N2O (", dollar, "/t N2O)"))
-    outN2oIndirect <- x[, , ] * 44 / 28 # US$/tN2O -> US$/tN
+                                     "Price|N2O (US$2017/t N2O)"))
+    outN2oIndirect <- x[, , ] * 44 / 28 # US$2017/tN2O -> US$2017/tN
     outN2oIndirect <- add_dimension(outN2oIndirect, dim = 3.1, nm = "n2o_n_indirect")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|CH4 (", dollar, "/t CH4)"))
+                                     "Price|CH4 (US$2017/t CH4)"))
     outCh4 <- x[, , ]
     outCh4 <- add_dimension(outCh4, dim = 3.1, nm = "ch4")
 
@@ -76,14 +68,6 @@ calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev =
     x[, , setToZero] <- 0
 
     description <- "GHG certificate prices for different scenarios based on data from REMIND-MAgPIE coupling"
-    
-    # convert US$ (for revisions before 4.118)
-    if (dollar == "US$2005") {
-      #convert from USD05MER to USD17MER based on USA values for all countries as the CO2 price is global.
-      x <- x * round(GDPuc::toolConvertSingle(1, "USA", unit_in = "constant 2005 US$MER",
-                                              unit_out = "constant 2017 US$MER"), 2)
-    }
-   
 
   } else if (datasource == "Strefler2021") {
     x <- readSource("Strefler2021", subtype = paste0("intensive_", rev))

--- a/R/calcGHGPrices.R
+++ b/R/calcGHGPrices.R
@@ -23,12 +23,15 @@
 calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev = numeric_version("0.1")) {
 
   if (datasource == "REMIND") {
+  
+    # NOTE: for versions < 4.118 readREMIND automatically reads US$2005 from REMIND reports
+    
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
                                      "Price|Carbon (US$2017/t CO2)"))
-    outC <- x * 44 / 12 # US$2017/tCO2 -> US$2017/tC
+    outC <- x * 44 / 12 # US$/tCO2 -> US$/tC
     outC <- add_dimension(outC, dim = 3.1, nm = "co2_c")
 
     x <- readSource("REMIND",
@@ -36,7 +39,7 @@ calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev =
                                      rev,
                                      "_",
                                      "Price|N2O (US$2017/t N2O)"))
-    outN2oDirect <- x * 44 / 28 # US$2017/tN2O -> US$2017/tN
+    outN2oDirect <- x * 44 / 28 # US$/tN2O -> US$/tN
     outN2oDirect <- add_dimension(outN2oDirect, dim = 3.1, nm = "n2o_n_direct")
 
     x <- readSource("REMIND",
@@ -44,7 +47,7 @@ calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev =
                                      rev,
                                      "_",
                                      "Price|N2O (US$2017/t N2O)"))
-    outN2oIndirect <- x[, , ] * 44 / 28 # US$2017/tN2O -> US$2017/tN
+    outN2oIndirect <- x[, , ] * 44 / 28 # US$/tN2O -> US$/tN
     outN2oIndirect <- add_dimension(outN2oIndirect, dim = 3.1, nm = "n2o_n_indirect")
 
     x <- readSource("REMIND",

--- a/R/calcGHGPrices.R
+++ b/R/calcGHGPrices.R
@@ -23,35 +23,43 @@
 calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev = numeric_version("0.1")) {
 
   if (datasource == "REMIND") {
+    
+    # use US$2005 for revisions before 4.118
+    if (rev < 4.118) {
+      dollar <- "US$2005"
+    } else {
+      dollar <- "US$2017"
+    }
+  
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|Carbon (US$2017/t CO2)"))
-    outC <- x * 44 / 12 # US$2017/tCO2 -> US$2017/tC
+                                     paste0("Price|Carbon (", dollar, "/t CO2)"))
+    outC <- x * 44 / 12 # US$/tCO2 -> US$/tC
     outC <- add_dimension(outC, dim = 3.1, nm = "co2_c")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|N2O (US$2017/t N2O)"))
-    outN2oDirect <- x * 44 / 28 # US$2017/tN2O -> US$2017/tN
+                                     "Price|N2O (", dollar, "/t N2O)"))
+    outN2oDirect <- x * 44 / 28 # US$/tN2O -> US$/tN
     outN2oDirect <- add_dimension(outN2oDirect, dim = 3.1, nm = "n2o_n_direct")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|N2O (US$2017/t N2O)"))
-    outN2oIndirect <- x[, , ] * 44 / 28 # US$2017/tN2O -> US$2017/tN
+                                     "Price|N2O (", dollar, "/t N2O)"))
+    outN2oIndirect <- x[, , ] * 44 / 28 # US$/tN2O -> US$/tN
     outN2oIndirect <- add_dimension(outN2oIndirect, dim = 3.1, nm = "n2o_n_indirect")
 
     x <- readSource("REMIND",
                     subtype = paste0("intensive_",
                                      rev,
                                      "_",
-                                     "Price|CH4 (US$2017/t CH4)"))
+                                     "Price|CH4 (", dollar, "/t CH4)"))
     outCh4 <- x[, , ]
     outCh4 <- add_dimension(outCh4, dim = 3.1, nm = "ch4")
 
@@ -68,6 +76,14 @@ calcGHGPrices <- function(emissions = "pollutants", datasource = "REMMAG", rev =
     x[, , setToZero] <- 0
 
     description <- "GHG certificate prices for different scenarios based on data from REMIND-MAgPIE coupling"
+    
+    # convert US$ (for revisions before 4.118)
+    if (dollar == "US$2005") {
+      #convert from USD05MER to USD17MER based on USA values for all countries as the CO2 price is global.
+      x <- x * round(GDPuc::toolConvertSingle(1, "USA", unit_in = "constant 2005 US$MER",
+                                              unit_out = "constant 2017 US$MER"), 2)
+    }
+   
 
   } else if (datasource == "Strefler2021") {
     x <- readSource("Strefler2021", subtype = paste0("intensive_", rev))

--- a/R/readREMIND.R
+++ b/R/readREMIND.R
@@ -105,6 +105,30 @@ readREMIND <- function(subtype) {
                                        replacement = "R32M46-\\1",
                                        indicator = indicator))
     }
+
+    if (revision >= 4.118) {
+      # Please refer to the 2025-R34M49/readme.txt for the source of the data
+      fileList <- c("2025-R34M49/REMIND_generic_C_SSP1-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP1-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP1-PkBudg650-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP2_lowEn-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP2_lowEn-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP2_lowEn-PkBudg650-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP2-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP2-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP2-PkBudg650-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP3-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP3-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP3-rollBack-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP5-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP5-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M49/REMIND_generic_C_SSP5-PkBudg650-rawluc-rem-5.mif")
+
+      out <- mbind(out, .readAndRename(fileList = fileList,
+                                       pattern = "C_SSP",
+                                       replacement = "R34M49-\\1",
+                                       indicator = indicator))
+    }
   }
 
   # shorten names of the REMIND scenarios

--- a/R/readREMIND.R
+++ b/R/readREMIND.R
@@ -25,6 +25,14 @@ readREMIND <- function(subtype) {
                                 as.list = FALSE,
                                 showSeparatorWarning = FALSE)[, , "REMIND"][, , indicator])
     }
+
+    # if data contains US$2005 convert them
+    if (grepl("US$2005", getNames(x)) {
+      #convert from USD05MER to USD17MER based on USA values for all countries as the CO2 price is global.
+      x <- x * round(GDPuc::toolConvertSingle(1, "USA", unit_in = "constant 2005 US$MER",
+                                              unit_out = "constant 2017 US$MER"), 2)
+    }
+    
     # remove model and variable name
     x <- collapseNames(x)
     # shorten names of the REMIND scenarios
@@ -37,6 +45,9 @@ readREMIND <- function(subtype) {
     subtype  <- strsplit(subtype, split = "_")
     revision <- numeric_version(unlist(subtype)[2])
     indicator <- unlist(subtype)[3]
+    
+    # for data that was added with revisions < 4.118 always look for US$2005
+    indicator <- gsub("US\\$2017", "US$2005", indicator)
 
     # Please refer to the 2019-R2M41/readme.txt for the source of the data
     fileList <- c("2019-R2M41/REMIND_generic_r8473-trunk-C_Budg600-rem-5.mif",
@@ -106,33 +117,36 @@ readREMIND <- function(subtype) {
                                        indicator = indicator))
     }
 
+    # for data that was added with revisions >= 4.118 look for US$2017
+    indicator <- gsub("US\\$2005", "US$2017", indicator)
+
     if (revision >= 4.118) {
-      # Please refer to the 2025-R34M49/readme.txt for the source of the data
-      fileList <- c("2025-R34M49/REMIND_generic_C_SSP1-NPi2025-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP1-PkBudg1000-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP1-PkBudg650-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP2_lowEn-NPi2025-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP2_lowEn-PkBudg1000-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP2_lowEn-PkBudg650-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP2-NPi2025-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP2-PkBudg1000-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP2-PkBudg650-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP3-NPi2025-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP3-PkBudg1000-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP3-rollBack-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP5-NPi2025-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP5-PkBudg1000-rawluc-rem-5.mif",
-                    "2025-R34M49/REMIND_generic_C_SSP5-PkBudg650-rawluc-rem-5.mif")
+      # Please refer to the 2025-R34M410/readme.txt for the source of the data
+      fileList <- c("2025-R34M410/REMIND_generic_C_SSP1-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP1-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP1-PkBudg650-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP2_lowEn-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP2_lowEn-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP2_lowEn-PkBudg650-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP2-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP2-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP2-PkBudg650-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP3-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP3-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP3-rollBack-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP5-NPi2025-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP5-PkBudg1000-rawluc-rem-5.mif",
+                    "2025-R34M410/REMIND_generic_C_SSP5-PkBudg650-rawluc-rem-5.mif")
 
       out <- mbind(out, .readAndRename(fileList = fileList,
-                                       pattern = "C_SSP",
-                                       replacement = "R34M49-\\1",
+                                       pattern = "C_(SSP)",
+                                       replacement = "R34M410-\\1",
                                        indicator = indicator))
     }
   }
 
   # shorten names of the REMIND scenarios
-  getNames(out) <- gsub("-rem-5", "", getNames(out))
+  getNames(out) <- gsub("(-rawluc|)-rem-5", "", getNames(out))
 
   return(out)
 

--- a/R/readREMIND.R
+++ b/R/readREMIND.R
@@ -27,12 +27,12 @@ readREMIND <- function(subtype) {
     }
 
     # if data contains US$2005 convert them
-    if (grepl("US$2005", getNames(x)) {
+    if (any(grepl("US\\$2005", getItems(x, dim = 3.3)))) {
       #convert from USD05MER to USD17MER based on USA values for all countries as the CO2 price is global.
       x <- x * round(GDPuc::toolConvertSingle(1, "USA", unit_in = "constant 2005 US$MER",
                                               unit_out = "constant 2017 US$MER"), 2)
     }
-    
+
     # remove model and variable name
     x <- collapseNames(x)
     # shorten names of the REMIND scenarios
@@ -45,7 +45,7 @@ readREMIND <- function(subtype) {
     subtype  <- strsplit(subtype, split = "_")
     revision <- numeric_version(unlist(subtype)[2])
     indicator <- unlist(subtype)[3]
-    
+
     # for data that was added with revisions < 4.118 always look for US$2005
     indicator <- gsub("US\\$2017", "US$2005", indicator)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRaT land data package
 
-R package **mrland**, version **0.65.10**
+R package **mrland**, version **0.65.11**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrland)](https://cran.r-project.org/package=mrland) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822083.svg)](https://doi.org/10.5281/zenodo.3822083) [![R build status](https://github.com/pik-piam/mrland/workflows/check/badge.svg)](https://github.com/pik-piam/mrland/actions) [![codecov](https://codecov.io/gh/pik-piam/mrland/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrland) [![r-universe](https://pik-piam.r-universe.dev/badges/mrland)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrland** in publications use:
 
-Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D, Sauer P, Tommey J (2025). "mrland: MadRaT land data package." doi:10.5281/zenodo.3822083 <https://doi.org/10.5281/zenodo.3822083>, Version: 0.65.10, <https://github.com/pik-piam/mrland>.
+Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D, Sauer P, Tommey J (2025). "mrland: MadRaT land data package." doi:10.5281/zenodo.3822083 <https://doi.org/10.5281/zenodo.3822083>, Version: 0.65.11, <https://github.com/pik-piam/mrland>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {mrland: MadRaT land data package},
   author = {Jan Philipp Dietrich and Abhijeet Mishra and Isabelle Weindl and Benjamin Leon Bodirsky and Xiaoxi Wang and Lavinia Baumstark and Ulrich Kreidenweis and David Klein and Nele Steinmetz and David Chen and Florian Humpenoeder and Patrick {von Jeetze} and Stephen Wirth and Felicitas Beier and David Hoetten and Pascal Sauer and Jake Tommey},
   doi = {10.5281/zenodo.3822083},
-  date = {2025-03-20},
+  date = {2025-04-01},
   year = {2025},
   url = {https://github.com/pik-piam/mrland},
-  note = {Version: 0.65.10},
+  note = {Version: 0.65.11},
 }
 ```

--- a/mrland.Rproj
+++ b/mrland.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 65afbe02-2dfe-4824-8f1f-6678b9dcea9e
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
Add new data for GHGPrices and 2ndBioDem from coupled runs from 2025-03-14 using REMIND 3.4.0.dev619 and MAgPIE develop (after release 4.9.1).