### PR TITLE
Faoupdatefix

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '13826440'
+ValidationKey: '13847454'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -60,9 +60,31 @@ jobs:
           lucode2::check(runLinter = FALSE)
 
       - name: Test coverage
+        if: ${{ github.event_name != 'pull_request' }}
         shell: Rscript {0}
         run: |
           nonDummyTests <- setdiff(list.files("./tests/testthat/"), c("test-dummy.R", "_snaps"))
-          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) covr::codecov(quiet = FALSE)
+          if(length(nonDummyTests) > 0 && !lucode2:::loadBuildLibraryConfig()[["skipCoverage"]]) {
+            coverage <- covr::package_coverage(quiet = FALSE)
+            # The following function might be unnecessary if r-lib/covr#616 gets merged
+            to_simple_codecov <- function(coverage) {
+              fullLineCoverage <- covr:::per_line(coverage)
+              data <- Map(function(fileCoverage) {
+                resultCoverage <- lapply(fileCoverage$coverage, jsonlite::unbox)
+                names(resultCoverage) <- seq_along(resultCoverage)
+                return(resultCoverage)
+              }, fullLineCoverage)
+              return(jsonlite::toJSON(list("coverage" = data), na = "null"))
+            }
+            writeLines(to_simple_codecov(coverage), "simple-codecov.json")
+          }
         env:
           NOT_CRAN: "true"
+
+      - uses: codecov/codecov-action@v4
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          file: ./simple-codecov.json
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrland: MadRaT land data package'
-version: 0.68.0
-date-released: '2025-09-02'
+version: 0.68.1
+date-released: '2025-09-03'
 abstract: The package provides land related data via the madrat framework.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrland
 Title: MadRaT land data package
-Version: 0.68.0
-Date: 2025-09-02
+Version: 0.68.1
+Date: 2025-09-03
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Abhijeet", "Mishra", role = "aut"),

--- a/R/fullMAGPIE.R
+++ b/R/fullMAGPIE.R
@@ -411,7 +411,7 @@ fullMAGPIE <- function(rev = numeric_version("0.1"), dev = "") {
              outputStatistics = stats, file = "f70_slaughter_feed_share.cs4")
   calcOutput("PYieldSlope",                              round = 2,
              outputStatistics = stats, file = "f70_pyld_slope_reg.cs4")
-  calcOutput("Production", round = 4, products = "kli", aggregate = TRUE, years = seq(1995, 2010, 5),
+  calcOutput("Production", round = 4, products = "kli", aggregate = TRUE, years = seq(1995, 2015, 5),
              outputStatistics = stats, file = "f70_hist_prod_livst.cs3")
   calcOutput("FactorCostsLivst", round = 4, aggregate = TRUE, years = seq(1995, 2015, 5),
              outputStatistics = stats, file = "f70_hist_factor_costs_livst.cs3")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRaT land data package
 
-R package **mrland**, version **0.68.0**
+R package **mrland**, version **0.68.1**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrland)](https://cran.r-project.org/package=mrland) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822083.svg)](https://doi.org/10.5281/zenodo.3822083) [![R build status](https://github.com/pik-piam/mrland/workflows/check/badge.svg)](https://github.com/pik-piam/mrland/actions) [![codecov](https://codecov.io/gh/pik-piam/mrland/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrland) [![r-universe](https://pik-piam.r-universe.dev/badges/mrland)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrland** in publications use:
 
-Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D, Sauer P, Tommey J (2025). "mrland: MadRaT land data package." doi:10.5281/zenodo.3822083 <https://doi.org/10.5281/zenodo.3822083>, Version: 0.68.0, <https://github.com/pik-piam/mrland>.
+Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D, Sauer P, Tommey J (2025). "mrland: MadRaT land data package." doi:10.5281/zenodo.3822083 <https://doi.org/10.5281/zenodo.3822083>, Version: 0.68.1, <https://github.com/pik-piam/mrland>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {mrland: MadRaT land data package},
   author = {Jan Philipp Dietrich and Abhijeet Mishra and Isabelle Weindl and Benjamin Leon Bodirsky and Xiaoxi Wang and Lavinia Baumstark and Ulrich Kreidenweis and David Klein and Nele Steinmetz and David Chen and Florian Humpenoeder and Patrick {von Jeetze} and Stephen Wirth and Felicitas Beier and David Hoetten and Pascal Sauer and Jake Tommey},
   doi = {10.5281/zenodo.3822083},
-  date = {2025-09-02},
+  date = {2025-09-03},
   year = {2025},
   url = {https://github.com/pik-piam/mrland},
-  note = {Version: 0.68.0},
+  note = {Version: 0.68.1},
 }
 ```


### PR DESCRIPTION
When running the pre-release tests for the FAO Update MAgPIE release, the FSEC test runs fail with a division by 0 error in the 70_livestock module. The culprit seems to be missing data in the input file because preprocessing is only running to 2010 for that specific input file.