### PR TITLE
Speeds up calcTradeBilateralFAOHarmonized

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '15476250'
+ValidationKey: '15500640'
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'
 - 'Warning: namespace ''.*'' is not available and has been replaced'

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'mrland: MadRaT land data package'
-version: 0.75.0
-date-released: '2026-07-01'
+version: 0.75.1
+date-released: '2026-07-06'
 abstract: The package provides land related data via the madrat framework.
 authors:
 - family-names: Dietrich

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: mrland
 Title: MadRaT land data package
-Version: 0.75.0
-Date: 2026-07-01
+Version: 0.75.1
+Date: 2026-07-06
 Authors@R: c(
     person("Jan Philipp", "Dietrich", , "dietrich@pik-potsdam.de", role = c("aut", "cre")),
     person("Abhijeet", "Mishra", role = "aut"),

--- a/R/calcTradeBilateralFAOHarmonized.R
+++ b/R/calcTradeBilateralFAOHarmonized.R
@@ -87,15 +87,25 @@ calcTradeBilateralFAOHarmonized <- function(yearly = TRUE) {
                                     names = getNames(tm),
                                     fill = 0)
 
-    for (t in getYears(tm, as.integer = TRUE)[-c(1, length(getYears(tm)))]) {
+    yrs <- getYears(tm, as.integer = TRUE)
+    n <- length(yrs)
+    if (n > 2) {
+      # interior target years and their adjacent-year sources; done for all years at once
+      # (vectorised replacement for the former year-by-year loop, identical result)
+      tgtY  <- yrs[-c(1, n)]     # years[2 .. n-1]  (interior targets, kept 0 at the ends)
+      lagY  <- yrs[-c(n - 1, n)] # years[1 .. n-2]  (the t-1 sources)
+      leadY <- yrs[-c(1, 2)]     # years[3 .. n]    (the t+1 sources)
 
       if (year == "both") {
-        yearAdjTrPatterns[, t, ] <-      (setYears(tm[, t - 1, ] / dimSums(tm[, t - 1, ], dim = 1.2), NULL) +
-                                            setYears(tm[, t + 1, ] / dimSums(tm[, t + 1, ], dim = 1.2), NULL)) / 2
+        norm <- tm / dimSums(tm, dim = 1.2)
+        yearAdjTrPatterns[, tgtY, ] <- (setYears(norm[, lagY, ], tgtY) +
+                                          setYears(norm[, leadY, ], tgtY)) / 2
       } else if (year == "after") {
-        yearAdjTrPatterns[, t, ] <-      setYears(tmS2[, t + 1, ] / dimSums(tmS2[, t + 1, ], dim = 1.2), NULL)
+        norm <- tmS2 / dimSums(tmS2, dim = 1.2)
+        yearAdjTrPatterns[, tgtY, ] <- setYears(norm[, leadY, ], tgtY)
       } else if (year == "before") {
-        yearAdjTrPatterns[, t, ] <-      setYears(tmS2[, t - 1, ] / dimSums(tmS2[, t - 1, ], dim = 1.2), NULL)
+        norm <- tmS2 / dimSums(tmS2, dim = 1.2)
+        yearAdjTrPatterns[, tgtY, ] <- setYears(norm[, lagY, ], tgtY)
       }
     }
 
@@ -109,7 +119,7 @@ calcTradeBilateralFAOHarmonized <- function(yearly = TRUE) {
   # make out object
   tmSout <- tmS
 
-  for (i in seq(1:5)) {
+  for (i in seq_len(5)) {
     # first both
     tmS2 <- .fillMiss(tmSout, year = "both")
     # then after
@@ -130,17 +140,17 @@ calcTradeBilateralFAOHarmonized <- function(yearly = TRUE) {
     dimSums(mbx[, , "ethanol"], dim = 1)
 
   nonmatch <- dimSums(tmSout, dim = 1.2) - mbi[, cyears, citems]
-  missing <- magclass::where(round(nonmatch, 3) < 0)$true$individual
-  missing <- as.data.frame(missing)
 
-
-  # Now we will fill all the others also with global exporters ratio
-  for (i in seq_along(missing[, 1])) {
-    tmSout[missing$im[i], missing$Year[i], missing$ItemCodeItem[i]] <-
-      mbi[missing$im[i], missing$Year[i], missing$ItemCodeItem[i]] *
-      mbx[, missing$Year[i], missing$ItemCodeItem[i]] /
-      dimSums(mbx[, missing$Year[i], missing$ItemCodeItem[i]], dim = 1)
-  }
+  # Now we will fill all the others also with global exporters ratio.
+  # Vectorised form of the former per-cell where()/for-loop: this is the same
+  # global-export-share distribution used for ethanol above (mbi * mbx / global exports),
+  # computed for every importer at once but written only into the cells that still
+  # under-fill the mass-balance imports (round(nonmatch, 3) < 0), broadcast across exporters.
+  globalRatioFill <- magpie_expand(mbi[, cyears, citems] * mbx[, cyears, citems] /
+                                     dimSums(mbx[, cyears, citems], dim = 1),
+                                   tmSout)
+  refill <- as.array(magpie_expand(round(nonmatch, 3) < 0, tmSout)) > 0
+  tmSout[refill] <- as.array(globalRatioFill)[refill]
 
   getItems(tmSout, dim = 1.2) <- gsub("[0-9]+", "", getItems(tmSout, dim = 1.2))
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MadRaT land data package
 
-R package **mrland**, version **0.75.0**
+R package **mrland**, version **0.75.1**
 
   [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3822083.svg)](https://doi.org/10.5281/zenodo.3822083) [![R build status](https://github.com/pik-piam/mrland/workflows/check/badge.svg)](https://github.com/pik-piam/mrland/actions) [![codecov](https://codecov.io/gh/pik-piam/mrland/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrland) [![r-universe](https://pik-piam.r-universe.dev/badges/mrland)](https://pik-piam.r-universe.dev/builds)
 
@@ -39,7 +39,7 @@ In case of questions / problems please contact Jan Philipp Dietrich <dietrich@pi
 
 To cite package **mrland** in publications use:
 
-Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D, Sauer P, Tommey J (2026). "mrland: MadRaT land data package." doi:10.5281/zenodo.3822083 <https://doi.org/10.5281/zenodo.3822083>, Version: 0.75.0, <https://github.com/pik-piam/mrland>.
+Dietrich J, Mishra A, Weindl I, Bodirsky B, Wang X, Baumstark L, Kreidenweis U, Klein D, Steinmetz N, Chen D, Humpenoeder F, von Jeetze P, Wirth S, Beier F, Hoetten D, Sauer P, Tommey J (2026). "mrland: MadRaT land data package." doi:10.5281/zenodo.3822083 <https://doi.org/10.5281/zenodo.3822083>, Version: 0.75.1, <https://github.com/pik-piam/mrland>.
 
 A BibTeX entry for LaTeX users is
 
@@ -48,9 +48,9 @@ A BibTeX entry for LaTeX users is
   title = {mrland: MadRaT land data package},
   author = {Jan Philipp Dietrich and Abhijeet Mishra and Isabelle Weindl and Benjamin Leon Bodirsky and Xiaoxi Wang and Lavinia Baumstark and Ulrich Kreidenweis and David Klein and Nele Steinmetz and David Chen and Florian Humpenoeder and Patrick {von Jeetze} and Stephen Wirth and Felicitas Beier and David Hoetten and Pascal Sauer and Jake Tommey},
   doi = {10.5281/zenodo.3822083},
-  date = {2026-07-01},
+  date = {2026-07-06},
   year = {2026},
   url = {https://github.com/pik-piam/mrland},
-  note = {Version: 0.75.0},
+  note = {Version: 0.75.1},
 }
 ```


### PR DESCRIPTION
This PR speeds up `R/calcTradeBilateralFAOHarmonized.R` from about 30 minutes to about 10 minutes by vectorizing two loops. I ran the old and the new version and results are exactly the same. 